### PR TITLE
Simple Android XML Escapes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -66,19 +66,19 @@
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
-        "version" : "1.2.2"
+        "revision" : "fddd1c00396eed152c45a46bea9f47b98e59301d",
+        "version" : "1.2.0"
       }
     },
     {
       "identity" : "xmlcoder",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MaxDesiatov/XMLCoder.git",
+      "location" : "https://github.com/CoreOffice/XMLCoder.git",
       "state" : {
-        "revision" : "c438dad94f6a243b411b70a4b4bac54595064808",
-        "version" : "0.15.0"
+        "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
+        "version" : "0.17.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         .package(url: "https://github.com/richardpiazza/Statement.git", .upToNextMajor(from: "0.7.1")),
         .package(url: "https://github.com/richardpiazza/Perfect-SQLite.git", .upToNextMajor(from: "5.1.1")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "1.2.0")),
-        .package(url: "https://github.com/MaxDesiatov/XMLCoder.git", .upToNextMajor(from: "0.15.0")),
+        .package(url: "https://github.com/CoreOffice/XMLCoder.git", .upToNextMajor(from: "0.15.0")),
         .package(url: "https://github.com/JohnSundell/Plot.git", .upToNextMajor(from: "0.11.0")),
         .package(url: "https://github.com/alexisakers/HTMLString.git", .upToNextMajor(from: "6.0.0")),
     ],

--- a/Sources/TranslationCatalogIO/ExpressionEncoder.swift
+++ b/Sources/TranslationCatalogIO/ExpressionEncoder.swift
@@ -13,7 +13,7 @@ public struct ExpressionEncoder {
     /// - throws: `Error`
     /// - parameters:
     ///   - expressions: The `Expression`s with `Translation`(s) to be encoded.
-    ///   - fileFormat: Format in which the `data` should be interpretted.
+    ///   - fileFormat: Format in which the `data` should be interpreted.
     /// - returns: The encoded translations in the request format.
     public static func encodeTranslations(
         for expressions: [Expression],

--- a/Sources/TranslationCatalogIO/Extensions/XML+Expression.swift
+++ b/Sources/TranslationCatalogIO/Extensions/XML+Expression.swift
@@ -9,10 +9,31 @@ extension XML {
                 .forEach(expressions) {
                     .element(named: "string", nodes: [
                         .attribute(named: "name", value: $0.key),
-                        .text($0.translations.first?.value ?? "")
+                        .text(($0.translations.first?.value ?? "").simpleAndroidXMLEscaped())
                     ])
                 }
             ])
         )
+    }
+}
+
+internal extension String {
+    func simpleAndroidXMLEscaped() -> String {
+        let replacements: [(Character, String)] = [
+            ("&", "&amp;"),
+//            ("\"", "&quot;"),
+            ("'", "\\'"),
+            ("<", "&lt;"),
+            (">", "&gt;"),
+            (" ", "&#160;") // NBSP
+        ]
+        
+        var updated = self
+        
+        for (character, replacement) in replacements {
+            updated = updated.replacingOccurrences(of: String(describing: character), with: replacement, range: nil)
+        }
+        
+        return updated
     }
 }

--- a/Tests/TranslationCatalogTests/XMLEscapingTests.swift
+++ b/Tests/TranslationCatalogTests/XMLEscapingTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import TranslationCatalogIO
+
+final class XMLEscapingTests: XCTestCase {
+    
+    func testSimpleEscaping() {
+        XCTAssertEqual("I am not Spartacus & lying".simpleAndroidXMLEscaped(), "I am not Spartacus &amp; lying")
+        XCTAssertEqual(#""I am Spartacus""#.simpleAndroidXMLEscaped(), "&quot;I am Spartacus&quot;")
+        XCTAssertEqual("I'm Spartacus".simpleAndroidXMLEscaped(), #"I\'m Spartacus"#)
+        XCTAssertEqual("I < Spartacus".simpleAndroidXMLEscaped(), "I &lt; Spartacus")
+        XCTAssertEqual("Spartacus > I".simpleAndroidXMLEscaped(), "Spartacus &gt; I")
+        XCTAssertEqual("Spartacus is me".simpleAndroidXMLEscaped(), "Spartacus&#160;is&#160;me")
+    }
+}


### PR DESCRIPTION
## 💬 Description
A small improvement to exporting Android XML files. The characters `&`, `'`, `<`, `>`, and non-breaking space are all escaped.