### PR TITLE
LocaleRepresentable

### DIFF
--- a/Sources/TranslationCatalog/Catalog.swift
+++ b/Sources/TranslationCatalog/Catalog.swift
@@ -4,7 +4,6 @@ import LocaleSupport
 /// Interface providing storage and retrieval of the `Expression`s and associated `Translation`s.
 public protocol Catalog {
     // MARK: - Project
-    
     /// Retrieve all `Project`s in the catalog.
     func projects() throws -> [Project]
     /// Retrieve all `Project`s that match the provided query parameters
@@ -75,4 +74,7 @@ public protocol Catalog {
     ///
     /// - parameter id: The unique identifier for the `Translation`.
     func deleteTranslation(_ id: Translation.ID) throws
+    
+    // MARK: - Metadata
+    func localeIdentifiers() throws -> Set<Locale.Identifier>
 }

--- a/Sources/TranslationCatalog/LocaleRepresentable.swift
+++ b/Sources/TranslationCatalog/LocaleRepresentable.swift
@@ -1,0 +1,21 @@
+import Foundation
+import LocaleSupport
+
+public protocol LocaleRepresentable {
+    var languageCode: LanguageCode { get }
+    var scriptCode: ScriptCode? { get }
+    var regionCode: RegionCode? { get }
+}
+
+public extension LocaleRepresentable {
+    var localeIdentifier: Locale.Identifier {
+        var output = languageCode.rawValue
+        if let scriptCode = self.scriptCode {
+            output += "-\(scriptCode.rawValue)"
+        }
+        if let regionCode = self.regionCode {
+            output += "_\(regionCode.rawValue)"
+        }
+        return output
+    }
+}

--- a/Sources/TranslationCatalog/Translation.swift
+++ b/Sources/TranslationCatalog/Translation.swift
@@ -31,16 +31,4 @@ extension Translation: Hashable {}
 extension Translation: Identifiable {
     public var id: UUID { uuid }
 }
-
-public extension Translation {
-    var localeIdentifier: Locale.Identifier {
-        var output = languageCode.rawValue
-        if let scriptCode = self.scriptCode {
-            output += "-\(scriptCode.rawValue)"
-        }
-        if let regionCode = self.regionCode {
-            output += "_\(regionCode.rawValue)"
-        }
-        return output
-    }
-}
+extension Translation: LocaleRepresentable {}

--- a/Sources/TranslationCatalogFilesystem/Documents/TranslationDocument.swift
+++ b/Sources/TranslationCatalogFilesystem/Documents/TranslationDocument.swift
@@ -23,3 +23,5 @@ extension Translation {
         )
     }
 }
+
+extension TranslationDocument: LocaleRepresentable {}

--- a/Sources/TranslationCatalogFilesystem/FilesystemCatalog.swift
+++ b/Sources/TranslationCatalogFilesystem/FilesystemCatalog.swift
@@ -534,4 +534,10 @@ public class FilesystemCatalog: Catalog {
         try translationDocuments[index].remove(from: translationsDirectory)
         translationDocuments.remove(at: index)
     }
+    
+    // MARK: - Metadata
+    
+    public func localeIdentifiers() throws -> Set<Locale.Identifier> {
+        Set(translationDocuments.map(\.localeIdentifier))
+    }
 }

--- a/Sources/TranslationCatalogSQLite/Entities/TranslationEntity.swift
+++ b/Sources/TranslationCatalogSQLite/Entities/TranslationEntity.swift
@@ -48,30 +48,41 @@ extension TranslationEntity {
         guard let foreignID = UUID(uuidString: expressionID) else {
             throw CatalogError.dataTypeConversion("Invalid UUID '\(expressionID)'")
         }
-        guard let languageCode = LanguageCode(rawValue: language) else {
-            throw CatalogError.dataTypeConversion("Invalid LanguageCode '\(language)'")
-        }
-        
-        let scriptCode: ScriptCode?
-        if let script = script {
-            guard let code = ScriptCode(rawValue: script) else {
-                throw CatalogError.dataTypeConversion("Invalid ScriptCode '\(script)'")
-            }
-            scriptCode = code
-        } else {
-            scriptCode = nil
-        }
-        
-        let regionCode: RegionCode?
-        if let region = region {
-            guard let code = RegionCode(rawValue: region) else {
-                throw CatalogError.dataTypeConversion("Invalid RegionCode '\(region)'")
-            }
-            regionCode = code
-        } else {
-            regionCode = nil
-        }
         
         return TranslationCatalog.Translation(uuid: id, expressionID: foreignID, languageCode: languageCode, scriptCode: scriptCode, regionCode: regionCode, value: value)
+    }
+}
+
+extension TranslationEntity: LocaleRepresentable {
+    var languageCode: LanguageCode {
+        guard let language = LanguageCode(rawValue: language) else {
+            fatalError("Invalid LanguageCode '\(language)'")
+        }
+        
+        return language
+    }
+    
+    var scriptCode: ScriptCode? {
+        guard let script = self.script else {
+            return nil
+        }
+        
+        guard let code = ScriptCode(rawValue: script) else {
+            return nil
+        }
+        
+        return code
+    }
+    
+    var regionCode: RegionCode? {
+        guard let region = self.region else {
+            return nil
+        }
+        
+        guard let code = RegionCode(rawValue: region) else {
+            return nil
+        }
+        
+        return code
     }
 }

--- a/Sources/TranslationCatalogSQLite/SQLiteCatalog.swift
+++ b/Sources/TranslationCatalogSQLite/SQLiteCatalog.swift
@@ -486,6 +486,12 @@ public class SQLiteCatalog: TranslationCatalog.Catalog {
             try db.run(renderStatement(.deleteTranslation(entity.id)))
         }
     }
+    
+    // MARK: - Metadata
+    public func localeIdentifiers() throws -> Set<Locale.Identifier> {
+        let translationEntities = try db.translationEntities(statement: renderStatement(.selectAllFromTranslation))
+        return Set(translationEntities.map(\.localeIdentifier))
+    }
 }
 
 private extension SQLiteCatalog {

--- a/Tests/TranslationCatalogTests/Extensions/Catalog+QueryAssertions.swift
+++ b/Tests/TranslationCatalogTests/Extensions/Catalog+QueryAssertions.swift
@@ -118,6 +118,19 @@ extension Catalog {
         let translation = try self.translation(.translation8)
         XCTAssertEqual(translation.localeIdentifier, "zh-Hans")
     }
+    
+    func assertLocaleIdentifiers() throws {
+        let localeIdentifiers = try self.localeIdentifiers()
+        XCTAssertEqual(localeIdentifiers.count, 6)
+        XCTAssertEqual(localeIdentifiers.sorted(), [
+            "en",
+            "es",
+            "fr",
+            "fr_CA",
+            "pt_BR",
+            "zh-Hans"
+        ])
+    }
 }
 
 struct CatalogData {

--- a/Tests/TranslationCatalogTests/FilesystemQueryCatalogTests.swift
+++ b/Tests/TranslationCatalogTests/FilesystemQueryCatalogTests.swift
@@ -72,4 +72,8 @@ final class FilesystemQueryCatalogTests: XCTestCase {
         try catalog.assertQueryTranslationsHavingOnly()
         try catalog.assertQueryTranslationId()
     }
+    
+    func testMetadataQueries() throws {
+        try catalog.assertLocaleIdentifiers()
+    }
 }

--- a/Tests/TranslationCatalogTests/SQLiteQueryCatalogTests.swift
+++ b/Tests/TranslationCatalogTests/SQLiteQueryCatalogTests.swift
@@ -68,6 +68,10 @@ final class SQLiteQueryCatalogTests: XCTestCase {
         try catalog.assertQueryTranslationId()
     }
     
+    func testMetadataQueries() throws {
+        try catalog.assertLocaleIdentifiers()
+    }
+    
     func testQueryProjectsHierarchy() throws {
         let projects = try catalog.projects(matching: SQLiteCatalog.ProjectQuery.hierarchy)
         XCTAssertEqual(projects.count, 3)
@@ -109,4 +113,6 @@ final class SQLiteQueryCatalogTests: XCTestCase {
         let translation = try catalog.translation(matching: SQLiteCatalog.TranslationQuery.primaryKey(9))
         XCTAssertEqual(translation.regionCode, .BR)
     }
+    
+    
 }


### PR DESCRIPTION
Adds a `LocalRepresentable` protocol for easy conversion to `Locale.Identifier`.
Also, add a `Catalog.localeIdentifiers()` metadata query to retrieve all identifiers in use for a particular catalog.