### PR TITLE
Locale-Aware Expression Encoder

### DIFF
--- a/Sources/TranslationCatalog/Expression.swift
+++ b/Sources/TranslationCatalog/Expression.swift
@@ -38,3 +38,25 @@ extension Expression: Hashable {}
 extension Expression: Identifiable {
     public var id: UUID { uuid }
 }
+
+public extension Expression {
+    /// The `Translation` that matches the `defaultLanguage` code of this instance.
+    var defaultTranslation: Translation? {
+        translations.first(where: { $0.languageCode == defaultLanguage })
+    }
+    
+    /// The `Translation` that matches the provided `Locale.Identifier`.
+    func translation(with identifier: Locale.Identifier?) -> Translation? {
+        translations.first(where: { $0.localeIdentifier == identifier })
+    }
+    
+    /// The `Translation` matching the `Locale.Identifier` or `defaultTranslation` if no matches found.
+    func translationOrDefault(with identifier: Locale.Identifier?) -> Translation? {
+        translation(with: identifier) ?? defaultTranslation
+    }
+    
+    /// The `Translation` that best matches the provided identifier, default if none, or first in the collection.
+    func translationOrDefaultOrFirst(with identifier: Locale.Identifier?) -> Translation? {
+        translationOrDefault(with: identifier) ?? translations.first
+    }
+}

--- a/Sources/TranslationCatalogIO/ExpressionEncoder.swift
+++ b/Sources/TranslationCatalogIO/ExpressionEncoder.swift
@@ -15,12 +15,12 @@ public struct ExpressionEncoder {
     ///   - expressions: The `Expression`s with `Translation`(s) to be encoded.
     ///   - fileFormat: Format in which the `data` should be interpreted.
     /// - returns: The encoded translations in the request format.
-    @available(*, deprecated, renamed: "encodeTranslations(for:fileFormat:localeIdentifier:)")
+    @available(*, deprecated, renamed: "encodeTranslations(for:fileFormat:localeIdentifier:defaultOrFirst:)")
     public static func encodeTranslations(
         for expressions: [Expression],
         fileFormat: FileFormat
     ) throws -> Data {
-        return try encodeTranslations(for: expressions, fileFormat: fileFormat, localeIdentifier: nil)
+        return try encodeTranslations(for: expressions, fileFormat: fileFormat, localeIdentifier: nil, defaultOrFirst: false)
     }
     
     /// Encode the a `Translation` of each `Expression` in the collection.
@@ -30,36 +30,38 @@ public struct ExpressionEncoder {
     ///   - expressions: The `Expression`s with `Translation`(s) to be encoded.
     ///   - fileFormat: Format in which the `data` should be interpreted.
     ///   - localeIdentifier: The `Locale.Identifier` used to map a specific `Translation`.
-    ///     When not provided, the _default_ or _first_ translation is used.
+    ///   - defaultOrFirst: Indicates a _default_ or _first_ translation is used when a locale-specific one is not found.
     /// - returns: The encoded translations in the request format.
     public static func encodeTranslations(
         for expressions: [Expression],
         fileFormat: FileFormat,
-        localeIdentifier: Locale.Identifier?
+        localeIdentifier: Locale.Identifier?,
+        defaultOrFirst: Bool
     ) throws -> Data {
         switch fileFormat {
         case .androidXML:
-            return exportAndroid(expressions, localeIdentifier: localeIdentifier)
+            return exportAndroid(expressions, localeIdentifier: localeIdentifier, defaultOrFirst: defaultOrFirst)
         case .appleStrings:
-            return exportApple(expressions, localeIdentifier: localeIdentifier)
+            return exportApple(expressions, localeIdentifier: localeIdentifier, defaultOrFirst: defaultOrFirst)
         case .json:
-            return try exportJson(expressions, localeIdentifier: localeIdentifier)
+            return try exportJson(expressions, localeIdentifier: localeIdentifier, defaultOrFirst: defaultOrFirst)
         }
     }
     
-    private static func exportAndroid(_ expressions: [Expression], localeIdentifier: Locale.Identifier?) -> Data {
+    private static func exportAndroid(_ expressions: [Expression], localeIdentifier: Locale.Identifier?, defaultOrFirst: Bool) -> Data {
         let sorted = expressions.sorted(by: { $0.key < $1.key})
-        let xml = XML.make(with: sorted, localeIdentifier: localeIdentifier)
+        let xml = XML.make(with: sorted, localeIdentifier: localeIdentifier, defaultOrFirst: defaultOrFirst)
         let raw = xml.render(indentedBy: .spaces(2))
         return raw.data(using: .utf8) ?? Data()
     }
     
-    private static func exportApple(_ expressions: [Expression], localeIdentifier: Locale.Identifier?) -> Data {
+    private static func exportApple(_ expressions: [Expression], localeIdentifier: Locale.Identifier?, defaultOrFirst: Bool) -> Data {
         let sorted = expressions.sorted(by: { $0.key < $1.key})
         var output: [String] = []
         
         sorted.forEach { (expression) in
-            guard let translation = expression.translationOrDefaultOrFirst(with: localeIdentifier) else {
+            let translation = defaultOrFirst ? expression.translationOrDefaultOrFirst(with: localeIdentifier) : expression.translation(with: localeIdentifier)
+            guard let translation = translation else {
                 return
             }
             
@@ -71,16 +73,9 @@ public struct ExpressionEncoder {
             .data(using: .utf8) ?? Data()
     }
     
-    private static func exportJson(_ expressions: [Expression], localeIdentifier: Locale.Identifier?) throws -> Data {
-        let filtered = expressions.compactMap { expression -> Expression? in
-            if expression.translation(with: localeIdentifier) != nil {
-                return expression
-            } else {
-                return nil
-            }
-        }
-        
-        let sequence = filtered.map { [$0.key: $0.translation(with: localeIdentifier)?.value ?? ""] }
+    private static func exportJson(_ expressions: [Expression], localeIdentifier: Locale.Identifier?, defaultOrFirst: Bool) throws -> Data {
+        let filtered = expressions.compactMap(localeIdentifier: localeIdentifier, defaultOrFirst: defaultOrFirst)
+        let sequence = filtered.map { [$0.key: $0.translations.first?.value ?? ""] }
         let dictionary = sequence.reduce(into: Dictionary<String, String>()) { partialResult, pair in
             partialResult[pair.keys.first!] = pair.values.first!
         }

--- a/Sources/TranslationCatalogIO/Extensions/Expression+IO.swift
+++ b/Sources/TranslationCatalogIO/Extensions/Expression+IO.swift
@@ -1,3 +1,5 @@
+import Foundation
+import LocaleSupport
 import TranslationCatalog
 import Plot
 
@@ -14,5 +16,20 @@ extension Expression {
             feature: feature,
             translations: translations
         )
+    }
+}
+
+extension Array where Element == Expression {
+    func compactMap(localeIdentifier: Locale.Identifier?, defaultOrFirst: Bool) -> [Expression] {
+        self.compactMap { expression -> Expression? in
+            let translation = defaultOrFirst ? expression.translationOrDefaultOrFirst(with: localeIdentifier) : expression.translation(with: localeIdentifier)
+            guard let translation = translation else {
+                return nil
+            }
+            
+            var mappedExpression = expression
+            mappedExpression.translations = [translation]
+            return mappedExpression
+        }
     }
 }

--- a/Sources/TranslationCatalogIO/Extensions/XML+Expression.swift
+++ b/Sources/TranslationCatalogIO/Extensions/XML+Expression.swift
@@ -1,20 +1,30 @@
+import Foundation
+import LocaleSupport
 import TranslationCatalog
 import Plot
 
 extension XML {
-    static func make(with expressions: [Expression]) -> Self {
+    static func make(with expressions: [Expression], localeIdentifier: Locale.Identifier?) -> Self {
+        let filtered = expressions.compactMap { expression -> Expression? in
+            if expression.translation(with: localeIdentifier) != nil {
+                return expression
+            } else {
+                return nil
+            }
+        }
+        
         return XML(
             .element(named: "resources", nodes: [
                 .attribute(named: "xmlns:tools", value: "http://schemas.android.com/tools"),
-                .forEach(expressions) {
+                .forEach(filtered) {
                     .element(named: "string", nodes: [
                         .attribute(named: "name", value: $0.key),
                         .attribute(
                             named: "formatted",
-                            value: $0.translations.first?.value.hasMultipleReplacements == true ? "false" : "",
+                            value: $0.translation(with: localeIdentifier)?.value.hasMultipleReplacements == true ? "false" : "",
                             ignoreIfValueIsEmpty: true
                         ),
-                        .text(($0.translations.first?.value ?? "").simpleAndroidXMLEscaped())
+                        .text(($0.translation(with: localeIdentifier)?.value ?? "").simpleAndroidXMLEscaped())
                     ])
                 }
             ])

--- a/Sources/TranslationCatalogIO/Extensions/XML+Expression.swift
+++ b/Sources/TranslationCatalogIO/Extensions/XML+Expression.swift
@@ -4,14 +4,8 @@ import TranslationCatalog
 import Plot
 
 extension XML {
-    static func make(with expressions: [Expression], localeIdentifier: Locale.Identifier?) -> Self {
-        let filtered = expressions.compactMap { expression -> Expression? in
-            if expression.translation(with: localeIdentifier) != nil {
-                return expression
-            } else {
-                return nil
-            }
-        }
+    static func make(with expressions: [Expression], localeIdentifier: Locale.Identifier?, defaultOrFirst: Bool) -> Self {
+        let filtered = expressions.compactMap(localeIdentifier: localeIdentifier, defaultOrFirst: defaultOrFirst)
         
         return XML(
             .element(named: "resources", nodes: [
@@ -21,10 +15,10 @@ extension XML {
                         .attribute(named: "name", value: $0.key),
                         .attribute(
                             named: "formatted",
-                            value: $0.translation(with: localeIdentifier)?.value.hasMultipleReplacements == true ? "false" : "",
+                            value: $0.translations.first?.value.hasMultipleReplacements == true ? "false" : "",
                             ignoreIfValueIsEmpty: true
                         ),
-                        .text(($0.translation(with: localeIdentifier)?.value ?? "").simpleAndroidXMLEscaped())
+                        .text(($0.translations.first?.value ?? "").simpleAndroidXMLEscaped())
                     ])
                 }
             ])

--- a/Tests/LocalizerTests/CatalogExportTests.swift
+++ b/Tests/LocalizerTests/CatalogExportTests.swift
@@ -14,6 +14,7 @@ final class CatalogExportTests: XCTestCase {
         XCTAssertEqual(localizer.output, """
         "APPLICATION_NAME" = "Lingua";
         "GREETING" = "Hello World!";
+        "HIDDEN_MESSAGE" = "solo en español";
         "PLATFORM_ANDROID" = "Android";
         "PLATFORM_APPLE" = "Apple";
         "PLATFORM_WEB" = "Web";
@@ -46,6 +47,7 @@ final class CatalogExportTests: XCTestCase {
         localizer.arguments = ["catalog", "export", "android", "en", "--path", resource.path]
         try localizer.run()
         
+        // TODO: Should this produce a line for 'HIDDEN_MESSAGE' in 'default language' instance?
         XCTAssertEqual(localizer.output, """
         <?xml version="1.0" encoding="UTF-8"?>
         
@@ -107,6 +109,7 @@ final class CatalogExportTests: XCTestCase {
         localizer.arguments = ["catalog", "export", "json", "en", "--path", resource.path]
         try localizer.run()
         
+        // TODO: Should this produce a line for 'HIDDEN_MESSAGE' in 'default language' instance?
         XCTAssertEqual(localizer.output, """
         {
           "APPLICATION_NAME" : "Lingua",
@@ -171,6 +174,7 @@ final class CatalogExportTests: XCTestCase {
         XCTAssertEqual(localizer.output, """
         "APPLICATION_NAME" = "Lingua";
         "GREETING" = "Hello World!";
+        "HIDDEN_MESSAGE" = "solo en español";
         "PLATFORM_ANDROID" = "Android";
         "PLATFORM_APPLE" = "Apple";
         "PLATFORM_WEB" = "Web";
@@ -211,6 +215,7 @@ final class CatalogExportTests: XCTestCase {
         localizer.arguments = ["catalog", "export", "android", "en", "--storage", "filesystem", "--path", directory.path]
         try localizer.run()
         
+        // TODO: Should this produce a line for 'HIDDEN_MESSAGE' in 'default language' instance?
         XCTAssertEqual(localizer.output, """
         <?xml version="1.0" encoding="UTF-8"?>
         
@@ -284,6 +289,7 @@ final class CatalogExportTests: XCTestCase {
         localizer.arguments = ["catalog", "export", "json", "en", "--storage", "filesystem", "--path", directory.path]
         try localizer.run()
         
+        // TODO: Should this produce a line for 'HIDDEN_MESSAGE' in 'default language' instance?
         XCTAssertEqual(localizer.output, """
         {
           "APPLICATION_NAME" : "Lingua",


### PR DESCRIPTION
Migrates the locale filtering from the `Export` command to the `ExpressionEncoder`.