### PR TITLE
Apple Dictionary Replacements

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,8 +20,14 @@ jobs:
     - name: Checkout Source
       uses: actions/checkout@v4
 
+    - name: Setup Toolchain
+      if: ${{ runner.os == 'Linux' }}
+      shell: bash
+      run: sudo apt-get install sqlite3 libsqlite3-dev
+
     - name: Swift Build
       uses: SwiftActions/SwiftBuild@main
 
     - name: Swift Test
       uses: SwiftActions/SwiftTest@main
+      

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,7 +11,7 @@ jobs:
   SwiftActions:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-15, ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   SwiftActions:
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-15, ubuntu-latest]
 

--- a/Sources/TranslationCatalogIO/ExpressionEncoder.swift
+++ b/Sources/TranslationCatalogIO/ExpressionEncoder.swift
@@ -65,7 +65,7 @@ public struct ExpressionEncoder {
                 return
             }
             
-            output.append("\"\(expression.key)\" = \"\(translation.value)\";")
+            output.append("\"\(expression.key)\" = \"\(translation.value.simpleAppleDictionaryEscaped())\";")
         }
         
         return output

--- a/Sources/TranslationCatalogIO/Extensions/XML+Expression.swift
+++ b/Sources/TranslationCatalogIO/Extensions/XML+Expression.swift
@@ -9,7 +9,6 @@ extension XML {
         
         return XML(
             .element(named: "resources", nodes: [
-                .attribute(named: "xmlns:tools", value: "http://schemas.android.com/tools"),
                 .forEach(filtered) {
                     .element(named: "string", nodes: [
                         .attribute(named: "name", value: $0.key),
@@ -27,14 +26,29 @@ extension XML {
 }
 
 internal extension String {
+    func simpleAppleDictionaryEscaped() -> String {
+        let replacements: [(Character, String)] = [
+            (#"""#, #"\""#),
+            ("\u{00a0}", "\\U00A0") // Non-Breaking Space
+        ]
+        
+        var updated = self
+        
+        for (character, replacement) in replacements {
+            updated = updated.replacingOccurrences(of: String(describing: character), with: replacement, range: nil)
+        }
+        
+        return updated
+    }
+    
     func simpleAndroidXMLEscaped() -> String {
         let replacements: [(Character, String)] = [
             ("&", "&amp;"),
-//            ("\"", "&quot;"),
+            (#"""#, #"\""#),
             ("'", "\\'"),
             ("<", "&lt;"),
             (">", "&gt;"),
-            (" ", "&#160;") // NBSP
+            (" ", "&#160;") // Non-Breaking Space
         ]
         
         var updated = self

--- a/Sources/localizer/Extensions/Arguments.swift
+++ b/Sources/localizer/Extensions/Arguments.swift
@@ -2,10 +2,10 @@ import Foundation
 import LocaleSupport
 import ArgumentParser
 
-extension LanguageCode: ExpressibleByArgument {}
-extension RegionCode: ExpressibleByArgument {}
-extension ScriptCode: ExpressibleByArgument {}
-extension UUID: ExpressibleByArgument {
+extension LanguageCode: @retroactive ExpressibleByArgument {}
+extension RegionCode: @retroactive ExpressibleByArgument {}
+extension ScriptCode: @retroactive ExpressibleByArgument {}
+extension UUID: @retroactive ExpressibleByArgument {
     public init?(argument: String) {
         self.init(uuidString: argument)
     }

--- a/Sources/localizer/Extensions/FileFormat+localizer.swift
+++ b/Sources/localizer/Extensions/FileFormat+localizer.swift
@@ -1,7 +1,7 @@
 import TranslationCatalogIO
 import ArgumentParser
 
-extension FileFormat: ExpressibleByArgument {
+extension FileFormat: @retroactive ExpressibleByArgument {
     var argument: String {
         switch self {
         case .androidXML: return "android-xml"

--- a/Sources/localizer/Extensions/RenderFormat+localizer.swift
+++ b/Sources/localizer/Extensions/RenderFormat+localizer.swift
@@ -1,5 +1,5 @@
 import TranslationCatalogIO
 import ArgumentParser
 
-extension RenderFormat: ExpressibleByArgument {
+extension RenderFormat: @retroactive ExpressibleByArgument {
 }

--- a/Tests/LocalizerTests/CatalogExportTests.swift
+++ b/Tests/LocalizerTests/CatalogExportTests.swift
@@ -51,7 +51,7 @@ final class CatalogExportTests: XCTestCase {
         XCTAssertEqual(localizer.output, """
         <?xml version="1.0" encoding="UTF-8"?>
         
-          <resources xmlns:tools="http://schemas.android.com/tools">
+          <resources>
             <string name="APPLICATION_NAME">Lingua</string>
             <string name="GREETING">Hello World!</string>
             <string name="PLATFORM_ANDROID">Android</string>
@@ -72,7 +72,7 @@ final class CatalogExportTests: XCTestCase {
         XCTAssertEqual(localizer.output, """
         <?xml version="1.0" encoding="UTF-8"?>
         
-          <resources xmlns:tools="http://schemas.android.com/tools">
+          <resources>
             <string name="GREETING">Hola Mundo!</string>
             <string name="HIDDEN_MESSAGE">solo en español</string>
           </resources>
@@ -90,7 +90,7 @@ final class CatalogExportTests: XCTestCase {
         XCTAssertEqual(localizer.output, """
         <?xml version="1.0" encoding="UTF-8"?>
         
-          <resources xmlns:tools="http://schemas.android.com/tools">
+          <resources>
             <string name="APPLICATION_NAME">Lingua</string>
             <string name="GREETING">Hola Mundo!</string>
             <string name="HIDDEN_MESSAGE">solo en español</string>
@@ -219,7 +219,7 @@ final class CatalogExportTests: XCTestCase {
         XCTAssertEqual(localizer.output, """
         <?xml version="1.0" encoding="UTF-8"?>
         
-          <resources xmlns:tools="http://schemas.android.com/tools">
+          <resources>
             <string name="APPLICATION_NAME">Lingua</string>
             <string name="GREETING">Hello World!</string>
             <string name="PLATFORM_ANDROID">Android</string>
@@ -244,7 +244,7 @@ final class CatalogExportTests: XCTestCase {
         XCTAssertEqual(localizer.output, """
         <?xml version="1.0" encoding="UTF-8"?>
         
-          <resources xmlns:tools="http://schemas.android.com/tools">
+          <resources>
             <string name="GREETING">Hola Mundo!</string>
             <string name="HIDDEN_MESSAGE">solo en español</string>
           </resources>
@@ -266,7 +266,7 @@ final class CatalogExportTests: XCTestCase {
         XCTAssertEqual(localizer.output, """
         <?xml version="1.0" encoding="UTF-8"?>
         
-          <resources xmlns:tools="http://schemas.android.com/tools">
+          <resources>
             <string name="APPLICATION_NAME">Lingua</string>
             <string name="GREETING">Hola Mundo!</string>
             <string name="HIDDEN_MESSAGE">solo en español</string>


### PR DESCRIPTION
Added a `simpleAppleDictionaryEscaped()` method for string replacements in Apple `Localizable.strings` exports. Additional tweets to Android `strings.xml` output as well.