### PR TITLE
Key/Value Insert

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [TranslationCatalog, TranslationCatalogIO, TranslationCatalogFilesystem, TranslationCatalogSQLite, localizer]

--- a/README.md
+++ b/README.md
@@ -2,13 +2,8 @@
 
 Swift toolkit for managing app localization &amp; internationalization.
 
-<p>
-  <img src="https://github.com/richardpiazza/TranslationCatalog/workflows/Swift/badge.svg?branch=main" />
-  <img src="https://img.shields.io/badge/Swift-5.6-orange.svg" />
-  <a href="https://twitter.com/richardpiazza">
-    <img src="https://img.shields.io/badge/twitter-@richardpiazza-blue.svg?style=flat" alt="Twitter: @richardpiazza" />
-  </a>
-</p>
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Frichardpiazza%2FTranslationCatalog%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/richardpiazza/TranslationCatalog)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Frichardpiazza%2FTranslationCatalog%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/richardpiazza/TranslationCatalog)
 
 ## Usage
 

--- a/Sources/localizer/Catalog+Insert.swift
+++ b/Sources/localizer/Catalog+Insert.swift
@@ -15,7 +15,8 @@ extension Catalog {
             subcommands: [
                 ProjectCommand.self,
                 ExpressionCommand.self,
-                TranslationCommand.self
+                TranslationCommand.self,
+                KeyValueCommand.self,
             ],
             defaultSubcommand: nil,
             helpNames: .shortAndLong
@@ -126,9 +127,7 @@ extension Catalog.Insert {
             print("Inserted Expression [\(id)] '\(expression.name)'")
         }
     }
-}
 
-extension Catalog.Insert {
     struct TranslationCommand: CatalogCommand {
         
         static var configuration: CommandConfiguration = .init(
@@ -178,6 +177,63 @@ extension Catalog.Insert {
             
             let id = try catalog.createTranslation(translation)
             print("Inserted Translation [\(id)] '\(value)'")
+        }
+    }
+
+    struct KeyValueCommand: CatalogCommand {
+
+        static var configuration: CommandConfiguration = CommandConfiguration(
+            commandName: "key-value",
+            abstract: "Quickly add a Expression=Translation pairing to the catalog.",
+            usage: nil,
+            discussion: "",
+            version: "1.0.0",
+            shouldDisplay: true,
+            subcommands: [],
+            defaultSubcommand: nil,
+            helpNames: .shortAndLong
+        )
+
+        @Argument(help: "Unique key that identifies the expression in translation files.")
+        var key: String
+
+        @Argument(help: "The translated string.")
+        var value: String
+
+        @Option(help: "Storage mechanism used to persist the catalog. [sqlite, filesystem]")
+        var storage: Catalog.Storage = .default
+
+        @Option(help: "Path to catalog to use in place of the application library.")
+        var path: String?
+
+        func run() async throws {
+            let catalog = try catalog(forStorage: storage)
+
+            let expression = Expression(
+                uuid: .zero,
+                key: key,
+                name: key,
+                defaultLanguage: .default,
+                context: nil,
+                feature: nil,
+                translations: []
+            )
+
+            let expressionId = try catalog.createExpression(expression)
+
+            let translation = Translation(
+                uuid: .zero,
+                expressionID: expressionId,
+                languageCode: .default,
+                scriptCode: nil,
+                regionCode: nil,
+                value: value
+            )
+
+            let translationId = try catalog.createTranslation(translation)
+
+            print("Inserted Expression / Translation [\(expressionId) / \(translationId)]")
+            print("\(key)='\(value)'")
         }
     }
 }


### PR DESCRIPTION
Adds an additional `insert` command to quickly insert new `expression=translation` pairs.