### PR TITLE
Projects by Expression

### DIFF
--- a/Sources/TranslationCatalog/CatalogQuery.swift
+++ b/Sources/TranslationCatalog/CatalogQuery.swift
@@ -7,6 +7,7 @@ public protocol CatalogQuery {}
 public enum GenericProjectQuery: CatalogQuery {
     case id(Project.ID)
     case named(String)
+    case expressionId(Expression.ID)
 }
 
 public enum GenericExpressionQuery: CatalogQuery {

--- a/Sources/TranslationCatalogCoreData/CoreDataCatalog.swift
+++ b/Sources/TranslationCatalogCoreData/CoreDataCatalog.swift
@@ -47,20 +47,23 @@ public class CoreDataCatalog: TranslationCatalog.Catalog {
     }
 
     public func projects(matching query: any TranslationCatalog.CatalogQuery) throws -> [TranslationCatalog.Project] {
+        let request = ProjectEntity.fetchRequest()
+        
         switch query {
         case GenericProjectQuery.named(let named):
-            let request = ProjectEntity.fetchRequest()
             request.predicate = NSPredicate(format: "%K CONTAINS[cd] %@", "name", named)
-
-            return try viewContext.performAndWait {
-                try viewContext
-                    .fetch(request)
-                    .map {
-                        try TranslationCatalog.Project($0)
-                    }
-            }
+        case GenericProjectQuery.expressionId(let expressionId):
+            request.predicate = NSPredicate(format: "ANY %K == %@", argumentArray: ["expressionEntities.id", expressionId])
         default:
             throw CatalogError.unhandledQuery(query)
+        }
+        
+        return try viewContext.performAndWait {
+            try viewContext
+                .fetch(request)
+                .map {
+                    try TranslationCatalog.Project($0)
+                }
         }
     }
 

--- a/Sources/TranslationCatalogFilesystem/FilesystemCatalog.swift
+++ b/Sources/TranslationCatalogFilesystem/FilesystemCatalog.swift
@@ -96,6 +96,9 @@ public class FilesystemCatalog: Catalog {
         case GenericProjectQuery.named(let name):
             documents = projectDocuments
                 .filter { $0.name.lowercased().contains(name.lowercased()) }
+        case GenericProjectQuery.expressionId(let expressionId):
+            documents = projectDocuments
+                .filter { $0.expressionIds.contains(expressionId) }
         default:
             throw CatalogError.unhandledQuery(query)
         }

--- a/Sources/TranslationCatalogSQLite/SQLiteCatalog.swift
+++ b/Sources/TranslationCatalogSQLite/SQLiteCatalog.swift
@@ -49,6 +49,13 @@ public class SQLiteCatalog: TranslationCatalog.Catalog {
         case GenericProjectQuery.named(let name):
             let entities = try db.projectEntities(statement: renderStatement(.selectProjects(withNameLike: name)))
             return try entities.map { try $0.project() }
+        case GenericProjectQuery.expressionId(let expressionId):
+            guard let entity = try db.expressionEntity(statement: renderStatement(.selectExpression(withID: expressionId))) else {
+                throw CatalogError.expressionId(expressionId)
+            }
+            
+            let entities = try db.projectEntities(statement: renderStatement(.selectProjects(withExpressionID: entity.id)))
+            return try entities.map { try $0.project() }
         default:
             throw CatalogError.unhandledQuery(query)
         }

--- a/Sources/TranslationCatalogSQLite/SQLiteStatement+Project.swift
+++ b/Sources/TranslationCatalogSQLite/SQLiteStatement+Project.swift
@@ -95,6 +95,23 @@ extension SQLiteStatement {
             )
         )
     }
+    
+    static func selectProjects(withExpressionID id: Int) -> Self {
+        SQLiteStatement(
+            .SELECT(
+                .column(ProjectEntity.id),
+                .column(ProjectEntity.uuid),
+                .column(ProjectEntity.name)
+            ),
+            .FROM(
+                .TABLE(ProjectEntity.self),
+                .JOIN_ON(ProjectExpressionEntity.self, attribute: ProjectExpressionEntity.projectID, equals: ProjectEntity.self, attribute: ProjectEntity.id)
+            ),
+            .WHERE(
+                .column(ProjectExpressionEntity.expressionID, op: .equal, value: id)
+            )
+        )
+    }
 
     static func insertProject(_ project: ProjectEntity) -> Self {
         SQLiteStatement(

--- a/Tests/TranslationCatalogTests/Extensions/Catalog+QueryAssertions.swift
+++ b/Tests/TranslationCatalogTests/Extensions/Catalog+QueryAssertions.swift
@@ -23,6 +23,14 @@ extension Catalog {
         projects = try self.projects(matching: GenericProjectQuery.named("class"))
         XCTAssertEqual(projects.count, 2)
     }
+    
+    /// Verify that a list of `Project`s can be found associated to an `Expression.ID`.
+    func assertQueryProjectsExpressionID() throws {
+        var projects = try projects(matching: GenericProjectQuery.expressionId(.expression2))
+        XCTAssertEqual(projects.count, 2)
+        projects = try self.projects(matching: GenericProjectQuery.expressionId(.expression5))
+        XCTAssertEqual(projects.count, 1)
+    }
 
     /// Verify that an existing `Project` can be found using its `id`.
     func assertQueryProjectId() throws {

--- a/Tests/TranslationCatalogTests/TestCases/QueryCatalogTestCase.swift
+++ b/Tests/TranslationCatalogTests/TestCases/QueryCatalogTestCase.swift
@@ -16,6 +16,7 @@ class QueryCatalogTestCase: XCTestCase {
     func testProjectQueries() throws {
         try catalog.assertQueryProjects()
         try catalog.assertQueryProjectsNamed()
+        try catalog.assertQueryProjectsExpressionID()
         try catalog.assertQueryProjectId()
         try catalog.assertQueryProjectNamed()
     }


### PR DESCRIPTION
Adds a new `GenericProjectQuery` for retrieval of `Project` by an matching `Expression.ID`.