### PR TITLE
Missing Locale Query

### DIFF
--- a/Sources/TranslationCatalog/CatalogQuery.swift
+++ b/Sources/TranslationCatalog/CatalogQuery.swift
@@ -21,6 +21,8 @@ public enum GenericExpressionQuery: CatalogQuery {
     case translationsHaving(Locale.LanguageCode, Locale.Script?, Locale.Region?)
     /// Expressions with Translations having a specified state
     case translationsHavingState(TranslationState)
+    /// Expressions that don't have a default value or Translation for _all_ of the specified locales.
+    case withoutAllLocales(Set<Locale>)
 }
 
 public enum GenericTranslationQuery: CatalogQuery {

--- a/Sources/TranslationCatalog/Expression.swift
+++ b/Sources/TranslationCatalog/Expression.swift
@@ -93,4 +93,9 @@ public struct Expression: Codable, Hashable, Identifiable, Sendable {
 
         return translation.value
     }
+
+    public func hasValuesForLocales(_ locales: Set<Locale>) -> Bool {
+        let currentLocales = Set([locale] + translations.map { $0.locale })
+        return locales.subtracting(currentLocales).isEmpty
+    }
 }

--- a/Sources/TranslationCatalogCoreData/CoreDataCatalog.swift
+++ b/Sources/TranslationCatalogCoreData/CoreDataCatalog.swift
@@ -241,6 +241,17 @@ public class CoreDataCatalog: TranslationCatalog.Catalog {
             )
         case GenericExpressionQuery.translationsHavingState(let state):
             fetchRequest.predicate = NSPredicate(format: "ANY %K == %@", "translationEntities.stateRawValue", state.rawValue)
+        case GenericExpressionQuery.withoutAllLocales(let locales):
+            // TODO: Render with a statement?
+            let expressions = try expressions()
+            let translations = try translations()
+            let mappedExpressions = expressions.map { expression in
+                TranslationCatalog.Expression(
+                    expression: expression,
+                    translations: translations.filter { $0.expressionId == expression.id }
+                )
+            }
+            return mappedExpressions.filter { !$0.hasValuesForLocales(locales) }
         default:
             throw CatalogError.unhandledQuery(query)
         }

--- a/Sources/TranslationCatalogFilesystem/FilesystemCatalog.swift
+++ b/Sources/TranslationCatalogFilesystem/FilesystemCatalog.swift
@@ -417,6 +417,18 @@ public class FilesystemCatalog: Catalog {
                     return TranslationCatalog.Expression(document: document, translations: translations)
                 }
                 .filter { !$0.translations.isEmpty }
+        case GenericExpressionQuery.withoutAllLocales(let locales):
+            let expressions = expressionDocuments
+                .map { document in
+                    let translations = translationDocuments
+                        .filter { $0.expressionID == document.id }
+                        .map {
+                            Translation(document: $0)
+                        }
+
+                    return Expression(document: document, translations: translations)
+                }
+            return expressions.filter { !$0.hasValuesForLocales(locales) }
         default:
             throw CatalogError.unhandledQuery(query)
         }

--- a/Sources/TranslationCatalogSQLite/SQLiteCatalog.swift
+++ b/Sources/TranslationCatalogSQLite/SQLiteCatalog.swift
@@ -190,6 +190,17 @@ public class SQLiteCatalog: TranslationCatalog.Catalog {
         case GenericExpressionQuery.translationsHavingState(let state):
             let entities = try db.expressionEntities(statement: renderStatement(.selectExpressionsWith(state: state)))
             return try entities.map { try $0.expression() }
+        case GenericExpressionQuery.withoutAllLocales(let locales):
+            // TODO: Render with a statement?
+            let expressions = try expressions()
+            let translations = try translations()
+            let mappedExpressions = expressions.map { expression in
+                TranslationCatalog.Expression(
+                    expression: expression,
+                    translations: translations.filter { $0.expressionId == expression.id }
+                )
+            }
+            return mappedExpressions.filter { !$0.hasValuesForLocales(locales) }
         default:
             throw CatalogError.unhandledQuery(query)
         }

--- a/Tests/TranslationCatalogTests/Extensions/Catalog+QueryAssertions.swift
+++ b/Tests/TranslationCatalogTests/Extensions/Catalog+QueryAssertions.swift
@@ -74,7 +74,7 @@ extension Catalog {
         var expressions = try expressions(matching: GenericExpressionQuery.translationsHaving(.french, nil, nil))
         XCTAssertEqual(expressions.count, 3)
         expressions = try self.expressions(matching: GenericExpressionQuery.translationsHaving(.french, nil, .canada))
-        XCTAssertEqual(expressions.count, 1)
+        XCTAssertEqual(expressions.count, 2)
     }
 
     /// Verify `Expression` entities can be retrieved matching _having only_ statements.
@@ -85,6 +85,20 @@ extension Catalog {
 
     func assertQueryExpressionsHavingState() throws {
         let expressions = try expressions(matching: GenericExpressionQuery.translationsHavingState(.needsReview))
+        XCTAssertEqual(expressions.count, 4)
+    }
+
+    func assertQueryExpressionsWithoutAllLocales() throws {
+        let locales = [
+            "en",
+            "en_GB",
+            "es",
+            "fr",
+            "fr_CA",
+            "pt_BR",
+            "zh-Hans",
+        ].map { Locale(identifier: $0) }
+        let expressions = try expressions(matching: GenericExpressionQuery.withoutAllLocales(Set(locales)))
         XCTAssertEqual(expressions.count, 4)
     }
 
@@ -103,7 +117,7 @@ extension Catalog {
     /// Verify an expected number of existing `Translation`.
     func assertQueryTranslations() throws {
         let translations = try translations()
-        XCTAssertEqual(translations.count, 13)
+        XCTAssertEqual(translations.count, 16)
     }
 
     /// Verify that existing `Translation`s can be found using a `Expression.ID`.
@@ -132,7 +146,7 @@ extension Catalog {
         XCTAssertEqual(translation.locale.identifier, "zh-Hans")
     }
 
-    func assertLocaleIdentifiers() throws {
+    func assertLocales() throws {
         let localeIdentifiers = try locales().map(\.identifier)
         XCTAssertEqual(localeIdentifiers.count, 7)
         XCTAssertEqual(localeIdentifiers.sorted(), [
@@ -170,7 +184,7 @@ enum CatalogData {
         languageCode: .english,
         context: "Button/Action Title",
         feature: "Buttons",
-        translations: [translation1, translation2, translation3]
+        translations: [translation1, translation2, translation3, translation14, translation15, translation16]
     )
     static let expression2 = Expression(
         id: .expression2,
@@ -328,6 +342,33 @@ enum CatalogData {
         region: .canada,
         state: .needsReview
     )
+    static let translation14 = TranslationCatalog.Translation(
+        id: .translation14,
+        expressionId: .expression1,
+        value: "sauver",
+        language: .french,
+        script: nil,
+        region: .canada,
+        state: .needsReview
+    )
+    static let translation15 = TranslationCatalog.Translation(
+        id: .translation15,
+        expressionId: .expression1,
+        value: "Guardar",
+        language: .portuguese,
+        script: nil,
+        region: .brazil,
+        state: .needsReview
+    )
+    static let translation16 = TranslationCatalog.Translation(
+        id: .translation16,
+        expressionId: .expression1,
+        value: "保存",
+        language: .chinese,
+        script: .hanSimplified,
+        region: nil,
+        state: .needsReview
+    )
 }
 
 extension UUID {
@@ -352,4 +393,7 @@ extension UUID {
     static let translation11 = UUID(uuidString: "3C48632D-C5FD-4307-A5DB-96FD1C0C5828")!
     static let translation12 = UUID(uuidString: "42DFEB9F-C9E6-457A-9F4E-EEAF645C9E0B")!
     static let translation13 = UUID(uuidString: "D57844A7-68D6-45E6-A260-CD7C5BC708D3")!
+    static let translation14 = UUID(uuidString: "4C493E43-59FB-484F-B1C7-F52DFA03B889")!
+    static let translation15 = UUID(uuidString: "9E5895C8-A9DD-4B52-BE22-0C005C84FA3A")!
+    static let translation16 = UUID(uuidString: "A825C6CD-4676-4A01-AA02-3CB3C78DDBE6")!
 }

--- a/Tests/TranslationCatalogTests/SQLiteQueryCatalogTests.swift
+++ b/Tests/TranslationCatalogTests/SQLiteQueryCatalogTests.swift
@@ -62,7 +62,7 @@ final class SQLiteQueryCatalogTests: QueryCatalogTestCase {
         let e3 = try XCTUnwrap(expressions.first(where: { $0.id == .expression3 }))
         let e4 = try XCTUnwrap(expressions.first(where: { $0.id == .expression4 }))
         let e5 = try XCTUnwrap(expressions.first(where: { $0.id == .expression5 }))
-        XCTAssertEqual(e1.translations.count, 3)
+        XCTAssertEqual(e1.translations.count, 6)
         XCTAssertEqual(e2.translations.count, 3)
         XCTAssertEqual(e3.translations.count, 3)
         XCTAssertEqual(e4.translations.count, 1)
@@ -75,7 +75,7 @@ final class SQLiteQueryCatalogTests: QueryCatalogTestCase {
     }
 
     func testQueryTranslationPrimaryKey() throws {
-        let translation = try catalog.translation(matching: SQLiteCatalog.TranslationQuery.primaryKey(9))
+        let translation = try catalog.translation(matching: SQLiteCatalog.TranslationQuery.primaryKey(12))
         XCTAssertEqual(translation.region, .brazil)
     }
 }

--- a/Tests/TranslationCatalogTests/TestCases/QueryCatalogTestCase.swift
+++ b/Tests/TranslationCatalogTests/TestCases/QueryCatalogTestCase.swift
@@ -28,6 +28,7 @@ class QueryCatalogTestCase: XCTestCase {
         try catalog.assertQueryExpressionsHaving()
         try catalog.assertQueryExpressionsHavingOnly()
         try catalog.assertQueryExpressionsHavingState()
+        try catalog.assertQueryExpressionsWithoutAllLocales()
         try catalog.assertQueryExpressionId()
         try catalog.assertQueryExpressionKey()
     }
@@ -41,6 +42,6 @@ class QueryCatalogTestCase: XCTestCase {
     }
 
     func testMetadataQueries() throws {
-        try catalog.assertLocaleIdentifiers()
+        try catalog.assertLocales()
     }
 }


### PR DESCRIPTION
A quick-and-dirty implementation of querying for expressions with missing locales.