### PR TITLE
Sorted Project Expression Ids

### DIFF
--- a/Sources/TranslationCatalogFilesystem/Documents/ProjectDocument.swift
+++ b/Sources/TranslationCatalogFilesystem/Documents/ProjectDocument.swift
@@ -7,6 +7,19 @@ struct ProjectDocument: Document {
     var expressionIds: Set<ExpressionDocument.ID>
 }
 
+extension ProjectDocument: Encodable {
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        if #available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *) {
+            try container.encode(expressionIds.sorted(), forKey: .expressionIds)
+        } else {
+            try container.encode(expressionIds, forKey: .expressionIds)
+        }
+    }
+}
+
 extension Project {
     init(document: ProjectDocument, expressions: [TranslationCatalog.Expression]) {
         self.init(

--- a/Tests/TranslationCatalogTests/FilesystemEncodingTests.swift
+++ b/Tests/TranslationCatalogTests/FilesystemEncodingTests.swift
@@ -1,0 +1,27 @@
+@testable import TranslationCatalog
+@testable import TranslationCatalogFilesystem
+import XCTest
+
+class FilesystemEncodingTests: XCTestCase {
+
+    func testProjectDocumentEncoding() throws {
+        let document = ProjectDocument(
+            id: UUID(uuidString: "24D67823-F859-40A1-88C2-A56F1170905B")!,
+            name: "Example",
+            expressionIds: [
+                UUID(uuidString: "7F9D2FF1-31C1-47A1-94EE-E23BB0A7AD2B")!,
+                UUID(uuidString: "592E488D-4E3C-490B-8725-C45FF7DEC872")!,
+                UUID(uuidString: "FB7C761C-9026-49C2-BBC7-9B7B897CAA6D")!,
+            ]
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(document)
+        let json = String(decoding: data, as: UTF8.self)
+        XCTAssertEqual(
+            json,
+            #"{"expressionIds":["592E488D-4E3C-490B-8725-C45FF7DEC872","7F9D2FF1-31C1-47A1-94EE-E23BB0A7AD2B","FB7C761C-9026-49C2-BBC7-9B7B897CAA6D"],"id":"24D67823-F859-40A1-88C2-A56F1170905B","name":"Example"}"#
+        )
+    }
+}


### PR DESCRIPTION
Overrides the default encoding of `ProjectDocument` to sort the associated expression IDs. This should lead to more stable diffs when using the 'filesystem' storage and a git repository.