### PR TITLE
Update XML Output formatting

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CoreOffice/XMLCoder.git",
       "state" : {
-        "revision" : "b1e944cbd0ef33787b13f639a5418d55b3bed501",
-        "version" : "0.17.1"
+        "revision" : "b2b5d72345bab9e1938a483cf862b498aeed3796",
+        "version" : "0.18.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         .package(url: "https://github.com/richardpiazza/CoreDataPlus.git", from: "0.5.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.1"),
         .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
-        .package(url: "https://github.com/CoreOffice/XMLCoder.git", from: "0.17.1"),
+        .package(url: "https://github.com/CoreOffice/XMLCoder.git", from: "0.18.1"),
         .package(url: "https://github.com/stephencelis/SQLite.swift.git", from: "0.16.0"),
     ],
     targets: [

--- a/Sources/TranslationCatalog/Catalog.swift
+++ b/Sources/TranslationCatalog/Catalog.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Interface providing storage and retrieval of the `Expression`s and associated `Translation`s.
 public protocol Catalog {
+
     // MARK: - Project
 
     /// Retrieve all `Project`s in the catalog.

--- a/Sources/TranslationCatalogFilesystem/FilesystemContainer.swift
+++ b/Sources/TranslationCatalogFilesystem/FilesystemContainer.swift
@@ -125,6 +125,7 @@ extension FilesystemContainer {
 }
 
 extension FilesystemContainer {
+
     // MARK: - Project
 
     public func projects() throws -> [Project] {

--- a/Sources/TranslationCatalogIO/Internal/Resource.swift
+++ b/Sources/TranslationCatalogIO/Internal/Resource.swift
@@ -13,7 +13,7 @@ struct Resource: Codable, DynamicNodeDecoding, DynamicNodeEncoding {
     let value: String
     let formatted: Bool?
 
-    static func nodeDecoding(for key: CodingKey) -> XMLDecoder.NodeDecoding {
+    static func nodeDecoding(for key: any CodingKey) -> XMLDecoder.NodeDecoding {
         switch key {
         case CodingKeys.name, CodingKeys.formatted:
             .attribute

--- a/Sources/TranslationCatalogIO/Internal/StringsXml.swift
+++ b/Sources/TranslationCatalogIO/Internal/StringsXml.swift
@@ -9,7 +9,7 @@ struct StringsXml: Codable, DynamicNodeDecoding, DynamicNodeEncoding {
 
     let resources: [Resource]
 
-    static func nodeDecoding(for key: CodingKey) -> XMLDecoder.NodeDecoding {
+    static func nodeDecoding(for key: any CodingKey) -> XMLDecoder.NodeDecoding {
         .element
     }
 
@@ -28,8 +28,8 @@ struct StringsXml: Codable, DynamicNodeDecoding, DynamicNodeEncoding {
 
     func encoded() throws -> Data {
         let encoder = XMLEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        let encoded = try encoder.encode(
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        return try encoder.encode(
             self,
             withRootKey: "resources",
             header: XMLHeader(
@@ -37,11 +37,6 @@ struct StringsXml: Codable, DynamicNodeDecoding, DynamicNodeEncoding {
                 encoding: "UTF-8"
             )
         )
-        var string = String(decoding: encoded, as: UTF8.self)
-        string = string.replacingOccurrences(of: "><resources>", with: ">\n<resources>")
-        string = string.replacingOccurrences(of: "><string", with: ">\n  <string")
-        string = string.replacingOccurrences(of: "></resources>", with: ">\n</resources>")
-        return string.data(using: .utf8) ?? encoded
     }
 }
 

--- a/Sources/TranslationCatalogSQLite/SQLiteStatement+Expression.swift
+++ b/Sources/TranslationCatalogSQLite/SQLiteStatement+Expression.swift
@@ -18,6 +18,7 @@ extension SQLiteStatement {
 // MARK: - Expression (Queries)
 
 extension SQLiteStatement {
+
     // MARK: Select Expressions
 
     static var selectAllFromExpression: Self {

--- a/Tests/LocalizerTests/ExportTests.swift
+++ b/Tests/LocalizerTests/ExportTests.swift
@@ -84,12 +84,12 @@ struct ExportTests {
         #expect(output == """
         <?xml version="1.0" encoding="UTF-8"?>
         <resources>
-          <string name="APPLICATION_NAME">Lingua</string>
-          <string name="GREETING">Hello World!</string>
-          <string name="HIDDEN_MESSAGE"></string>
-          <string name="PLATFORM_ANDROID">Android</string>
-          <string name="PLATFORM_APPLE">Apple</string>
-          <string name="PLATFORM_WEB">Web</string>
+            <string name="APPLICATION_NAME">Lingua</string>
+            <string name="GREETING">Hello World!</string>
+            <string name="HIDDEN_MESSAGE"></string>
+            <string name="PLATFORM_ANDROID">Android</string>
+            <string name="PLATFORM_APPLE">Apple</string>
+            <string name="PLATFORM_WEB">Web</string>
         </resources>
 
         """)
@@ -107,8 +107,8 @@ struct ExportTests {
         #expect(output == """
         <?xml version="1.0" encoding="UTF-8"?>
         <resources>
-          <string name="GREETING">Hola Mundo!</string>
-          <string name="HIDDEN_MESSAGE">solo en español</string>
+            <string name="GREETING">Hola Mundo!</string>
+            <string name="HIDDEN_MESSAGE">solo en español</string>
         </resources>
 
         """)
@@ -126,12 +126,12 @@ struct ExportTests {
         #expect(output == """
         <?xml version="1.0" encoding="UTF-8"?>
         <resources>
-          <string name="APPLICATION_NAME">Lingua</string>
-          <string name="GREETING">Hola Mundo!</string>
-          <string name="HIDDEN_MESSAGE">solo en español</string>
-          <string name="PLATFORM_ANDROID">Android</string>
-          <string name="PLATFORM_APPLE">Apple</string>
-          <string name="PLATFORM_WEB">Web</string>
+            <string name="APPLICATION_NAME">Lingua</string>
+            <string name="GREETING">Hola Mundo!</string>
+            <string name="HIDDEN_MESSAGE">solo en español</string>
+            <string name="PLATFORM_ANDROID">Android</string>
+            <string name="PLATFORM_APPLE">Apple</string>
+            <string name="PLATFORM_WEB">Web</string>
         </resources>
 
         """)

--- a/Tests/TranslationCatalogTests/ExpressionEncoderTests.swift
+++ b/Tests/TranslationCatalogTests/ExpressionEncoderTests.swift
@@ -42,9 +42,9 @@ struct ExpressionEncoderTests {
         #expect(output == """
         <?xml version="1.0" encoding="UTF-8"?>
         <resources>
-          <string name="EXP_01">Hello World!</string>
-          <string name="EXP_02">Hello %s!</string>
-          <string formatted="false" name="EXP_03">Hello %s, welcome to %s!</string>
+            <string name="EXP_01">Hello World!</string>
+            <string name="EXP_02">Hello %s!</string>
+            <string formatted="false" name="EXP_03">Hello %s, welcome to %s!</string>
         </resources>
         """)
     }


### PR DESCRIPTION
Updated `XMLCoder` which included a [fix](https://github.com/CoreOffice/XMLCoder/pull/296) for outputting in the preferred format.